### PR TITLE
Add reports_integrations

### DIFF
--- a/src/python_homeassistant_analytics/models.py
+++ b/src/python_homeassistant_analytics/models.py
@@ -40,6 +40,7 @@ class CurrentAnalytics(DataClassORJSONMixin):
     average_addons: int = field(metadata=field_options(alias="avg_addons"))
     average_states: int = field(metadata=field_options(alias="avg_states"))
     integrations: dict[str, int]
+    reports_integrations: int
 
 
 @dataclass

--- a/tests/__snapshots__/test_python_homeassistant_analytics.ambr
+++ b/tests/__snapshots__/test_python_homeassistant_analytics.ambr
@@ -29102,6 +29102,7 @@
         'zwave_me': 64,
       }),
       'last_updated': datetime.datetime(2024, 1, 8, 11, 2, 38, 591000, tzinfo=datetime.timezone.utc),
+      'reports_integrations': 248192,
     }),
   })
 # ---
@@ -30404,6 +30405,7 @@
       'zwave_me': 64,
     }),
     'last_updated': datetime.datetime(2024, 1, 10, 11, 23, 11, 95000, tzinfo=datetime.timezone.utc),
+    'reports_integrations': 249256,
   })
 # ---
 # name: test_custom_integrations


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Add reports_integrations, I would like to add a sensor for this in HomeAssistant.
That way I can calculate the % of users for each integration I am intrested in.
(already have this working in my dev env).

Could you also bump the version of this library?

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
