### PR TITLE
Allow fetching list of integrations from different environments

### DIFF
--- a/src/python_homeassistant_analytics/__init__.py
+++ b/src/python_homeassistant_analytics/__init__.py
@@ -9,6 +9,7 @@ from .models import (
     Analytics,
     CurrentAnalytics,
     CustomIntegration,
+    Environment,
     InstallationTypes,
     Integration,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "Analytics",
     "CurrentAnalytics",
     "CustomIntegration",
+    "Environment",
     "HomeassistantAnalyticsClient",
     "HomeassistantAnalyticsConnectionError",
     "HomeassistantAnalyticsError",

--- a/src/python_homeassistant_analytics/models.py
+++ b/src/python_homeassistant_analytics/models.py
@@ -10,6 +10,14 @@ from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 
+class Environment(StrEnum):
+    """Environment."""
+
+    CURRENT = "current"
+    NEXT = "next"
+    RC = "rc"
+
+
 @dataclass
 class InstallationTypes(DataClassORJSONMixin):
     """InstallationTypes model."""

--- a/src/python_homeassistant_analytics/python_homeassistant_analytics.py
+++ b/src/python_homeassistant_analytics/python_homeassistant_analytics.py
@@ -102,7 +102,7 @@ class HomeassistantAnalyticsClient:
 
     async def get_integrations(self) -> dict[str, Integration]:
         """Get integrations."""
-        response = await self._request("home-assistant.io", "integrations.json")
+        response = await self._request("next.home-assistant.io", "integrations.json")
         obj = orjson.loads(response)  # pylint: disable=no-member
         return {key: Integration.from_dict(value) for key, value in obj.items()}
 

--- a/src/python_homeassistant_analytics/python_homeassistant_analytics.py
+++ b/src/python_homeassistant_analytics/python_homeassistant_analytics.py
@@ -21,6 +21,7 @@ from python_homeassistant_analytics.models import (
     Analytics,
     CurrentAnalytics,
     CustomIntegration,
+    Environment,
     Integration,
 )
 
@@ -100,9 +101,19 @@ class HomeassistantAnalyticsClient:
         )
         return CurrentAnalytics.from_json(response)
 
-    async def get_integrations(self) -> dict[str, Integration]:
+    async def get_integrations(
+        self,
+        environment: Environment = Environment.CURRENT,
+    ) -> dict[str, Integration]:
         """Get integrations."""
-        response = await self._request("next.home-assistant.io", "integrations.json")
+        prefix = {
+            Environment.RC: "rc.",
+            Environment.NEXT: "next.",
+        }.get(environment, "")
+        response = await self._request(
+            f"{prefix}home-assistant.io",
+            "integrations.json",
+        )
         obj = orjson.loads(response)  # pylint: disable=no-member
         return {key: Integration.from_dict(value) for key, value in obj.items()}
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -3,7 +3,7 @@
 from importlib import metadata
 
 HOMEASSISTANT_ANALYTICS_URL = "https://analytics.home-assistant.io"
-HOMEASSISTANT_URL = "https://next.home-assistant.io"
+HOMEASSISTANT_URL = "https://home-assistant.io"
 
 version = metadata.version("python_homeassistant_analytics")
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -3,7 +3,7 @@
 from importlib import metadata
 
 HOMEASSISTANT_ANALYTICS_URL = "https://analytics.home-assistant.io"
-HOMEASSISTANT_URL = "https://home-assistant.io"
+HOMEASSISTANT_URL = "https://next.home-assistant.io"
 
 version = metadata.version("python_homeassistant_analytics")
 


### PR DESCRIPTION
# Proposed Changes

Get the list of integrations from next.home-assistant.io to allow tracking integrations that are soon to launch or launched in beta.

## Related Issues
